### PR TITLE
Bugfix/1-4 管理者登録後のダブルサミット対策

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -78,19 +78,21 @@ public class AdministratorController {
 	 */
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult result, Model model) {
-		//メールアドレスの重複があれば入力場面に遷移
-		Administrator administrator = new Administrator();
-		administrator = administratorService.findByMailAddress(form.getMailAddress());
-		if(administrator != null ){
-			model.addAttribute("duplicationMessage", "Mailアドレスが重複しています");			
-			return "administrator/insert";
-		} else if(result.hasErrors()){
+		if(result.hasErrors()){
 			//入力項目にエラーがあれば入力画面に遷移する
 			return "administrator/insert";
 		} 
+		
 		// フォームからドメインにプロパティ値をコピー
+		//メールアドレスの重複があれば入力場面に遷移
+		Administrator administrator = administratorService.findByMailAddress(form.getMailAddress());
+		if(administrator != null ){
+			model.addAttribute("duplicationMessage", "Mailアドレスが重複しています");			
+			return "administrator/insert";
+		} 
+		administrator = new Administrator();
 		BeanUtils.copyProperties(form, administrator);
-		administratorService.insert(administrator);
+			administratorService.insert(administrator);
 		return "redirect:/";
 	}
 


### PR DESCRIPTION
管理者登録後、更新ボタンを押すと同じリクエストが２回送信されてしまうような現象が出ているのでリダイレクト処理をしてダブルサブミット対策をしています。