### PR TITLE
bugfix/1-4 パスワードと確認用パスワードの相関チェック機能の実装

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -80,7 +80,14 @@ public class AdministratorController {
 			//入力項目にエラーがあれば入力画面に遷移する
 			return "administrator/insert";
 		} 
-		
+
+		//パスワードの相関チェック
+		//パスワードと確認用パスワードが不一致の際は入力画面に遷移
+		if(form.getPassword() != form.getPasswordConfirmation()) {
+			model.addAttribute("errorMessage", "パスワードと確認用パスワードは一致させてください");
+			return "administrator/insert";
+		}
+
 		// フォームからドメインにプロパティ値をコピー
 		//メールアドレスの重複があれば入力場面に遷移
 		Administrator administrator = administratorService.findByMailAddress(form.getMailAddress());

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -83,7 +83,7 @@ public class AdministratorController {
 
 		//パスワードの相関チェック
 		//パスワードと確認用パスワードが不一致の際は入力画面に遷移
-		if(form.getPassword() != form.getPasswordConfirmation()) {
+		if(!(form.getPassword().equals(form.getPasswordConfirmation()))) {
 			model.addAttribute("errorMessage", "パスワードと確認用パスワードは一致させてください");
 			return "administrator/insert";
 		}

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -2,6 +2,7 @@ package com.example.form;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 /**
  * 管理者情報登録時に使用するフォーム.
@@ -11,13 +12,41 @@ import jakarta.validation.constraints.NotBlank;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank(message = "名前は必須です")
 	private String name;
 	/** メールアドレス */
 	@NotBlank (message = "メールアドレスは入力してください")
 	@Email (message = "Email形式で入力してください")
 	private String mailAddress;
 	/** パスワード */
+	@Size(min=8,max=16, message="パスワードは8文字以上16文字以下で入力してください")
 	private String password;
+
+	/**確認用パスワード */
+	@Size(min=8,max=16, message="パスワードは8文字以上16文字以下で入力してください")
+	private String passwordConfirmation;
+
+	// /** 相関チェック */
+	// @AssertTrue(message ="passwordと確認用パスワードは同一にしてください。")
+	// private boolean isPasswordValid() {
+	// 	if( password == null || password.isEmpty()) {
+	// 		return true;
+	// 	}
+	// 	return password.equals(passwordConfirmation);
+	// }
+
+	public InsertAdministratorForm() {
+	}
+
+	public InsertAdministratorForm(String name,
+			@NotBlank(message = "メールアドレスは入力してください") @Email(message = "Email形式で入力してください") String mailAddress,
+			@Size(min = 8, max = 16, message = "パスワードは8文字以上16文字以下で入力してください") String password,
+			@Size(min = 8, max = 16, message = "パスワードは8文字以上16文字以下で入力してください") String passwordConfirmation) {
+		this.name = name;
+		this.mailAddress = mailAddress;
+		this.password = password;
+		this.passwordConfirmation = passwordConfirmation;
+	}
 
 	public String getName() {
 		return name;
@@ -43,10 +72,17 @@ public class InsertAdministratorForm {
 		this.password = password;
 	}
 
+	public String getPasswordConfirmation() {
+		return passwordConfirmation;
+	}
+
+	public void setPasswordConfirmation(String passwordConfirmation) {
+		this.passwordConfirmation = passwordConfirmation;
+	}
+
 	@Override
 	public String toString() {
 		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ "]";
+				+ ", passwordConfirmation=" + passwordConfirmation + "]";
 	}
-
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -125,6 +125,30 @@
                     </div>
                   </div>
                 </div>
+                <!-- 確認用パスワード -->
+                <div class="form-group">
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <label for="passwordConfirmation"> 確認用パスワード: </label>
+                      <label
+                        th:errors="*{passwordConfirmation}"
+                        class="error-messages"
+                      >
+                        確認用パスワードを入力してください
+                      </label>
+                      <label th:text="${errorMessage}" style="color:red"></label>
+                      <input
+                        type="password"
+                        name="passwordConfirmation"
+                        id="passwordConfirmation"
+                        class="form-control"
+                        placeholder="passwordConfirmation"
+                        th:field="*{passwordConfirmation}"
+                        th:errorclass="error-input"
+                      />
+                    </div>
+                  </div>
+                </div>
                 <!-- 登録ボタン -->
                 <div class="form-group">
                   <div class="row">


### PR DESCRIPTION
登録者確認画面で登録する際に、パスワードと確認用パスワードが不一致の際は、登録者画面に再度遷移するように機能追加しています。